### PR TITLE
Fix for build failures at -verbose 5 level

### DIFF
--- a/src/oebuild/oebuild_parallel.ml
+++ b/src/oebuild/oebuild_parallel.ml
@@ -154,7 +154,22 @@ let create_process ?(jobs=0) ~verbose cb_create_command cb_at_exit dag leaf erro
       let at_exit = function
         | None ->
           (*output.exit_code <- exit_code;*)
-          if Buffer.length output.err > 0 then (errors := output :: !errors)
+          if Buffer.length output.err > 0 then
+            (* Wait, wait, what is happening here?
+
+               We use a heuristic to check if compilation succeeded or failed.
+               If the is some output to stderr, we assume the that compilation
+               failed.
+               But with if -verbose level is 5 the -verbose option is passed to
+               OCaml compilers and those output some additional info to stderr
+               prefixing it with '+'
+
+               Probably better not to use -verbose level 5 unless you know what
+               you're doing or are to help with debugging.
+            *)
+            let err = Buffer.contents output.err |> String.trim in
+            if err.[0] <> '+' then (errors := output :: !errors)
+            else messages := output :: !messages
           else messages := output :: !messages;
           Mutex.lock dag.mutex;
           Dag.remove_leaf dag.graph leaf;


### PR DESCRIPTION
Now, this is a funny fix. First a little bit about how the parallel
compilation works.

First we creae a DAG (directed acyclic graph) of dependencies. Then we
pick the leaves i.e node with no dependencies an try to compile them in
parallel. Asynchronously.

The we sleep for 50 milliseconds. Then we do it it again. If the
compilation process has finished the leaf (node) is removed from the DAG
and we will have another set of leaves to proceed. If not we get the
same set of leaves, but if the node is marked as `in_processing` we just
ignore it.

As long as the compilation succeeds the leaves are removed one by one
until 0 remain and the build succeeds.

If the compilation of one node fails, the whole build fails.

So far so good. But what has `-verbose 5` level do with it?

Because in order to check if the compilation succeded or failed an
heuristic is used. If the compilation (an external process) did not
write to `stderr` we assume the all is fine and  dandy. But if there are
messages  in `stderr` we assume that the compilation failed.

And here is problem. When verbose level is 5 the option `-verbose` is
passed to OCaml compilers. And

```
ocamlopt.opt -c hello.ml
```
will produce:
```
$ ocamlopt.opt -c hello.ml
+ as   'hello.o' '/tmp/camlasm7777.s'
```

and the last line is written to `stderr`. Oops. The fix is cludge, but
is a fix.