### PR TITLE
Syntax hightlight for annotations & other changes

### DIFF
--- a/src/lexical.ml
+++ b/src/lexical.ml
@@ -210,6 +210,7 @@ let tag ?start ?stop (tb : GText.buffer) =
           | INFIXOP4 _
           | PREFIXOP _
           | HASH | HASHOP _
+          | BANG
             -> "infix"
           | LABEL _
           | OPTLABEL _
@@ -247,20 +248,22 @@ let tag ?start ?stop (tb : GText.buffer) =
           | LBRACE -> in_record := true; in_record_label := true; "symbol"
           | RBRACE -> in_record := false; in_record_label := false; "symbol"
           | EQUAL when !in_record -> in_record_label := false; "symbol"
-          | LPAREN | RPAREN | LBRACKET | BARRBRACKET | LBRACKETLESS | GREATERRBRACKET
+          | LPAREN | RPAREN | LBRACKET | BARRBRACKET | LBRACKETLESS | LBRACKETGREATER | GREATERRBRACKET
           | LBRACELESS | GREATERRBRACE | LBRACKETBAR | LESSMINUS
           | EQUAL | PLUS | MINUS | STAR | QUOTE | SEMI | SEMISEMI | MINUSGREATER
           | COMMA | DOT | DOTDOT | COLONCOLON | COLONEQUAL | UNDERSCORE
-          | PLUSDOT | MINUSDOT
+          | PLUSDOT | MINUSDOT | LESS | GREATER
           | PLUSEQ | PERCENT
+          | COLONGREATER
           | DOTOP _
             -> "symbol"
           | LBRACKETAT | LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETATAT | LBRACKETATATAT
             -> in_annotation:= true; "annotation"
           | RBRACKET -> if !in_annotation then (in_annotation := false; "annotation") else "symbol"
           | ASSERT -> "custom"
+          | DOCSTRING _ | COMMENT _ -> "comment"
+          | EOL -> ""
           | EOF -> raise End_of_file
-          | _ -> ""
         in
         if tag <> "" then begin
           tb#apply_tag_by_name tag ~start:(tpos start) ~stop:(tpos stop);

--- a/src/lexical.ml
+++ b/src/lexical.ml
@@ -200,6 +200,7 @@ let tag ?start ?stop (tb : GText.buffer) =
             -> "structure"
           | CHAR _
           | STRING _
+          | QUOTED_STRING_EXPR _ | QUOTED_STRING_ITEM _
             -> "char"
           (*| BACKQUOTE*)
           | INFIXOP0 _

--- a/src/lexical.ml
+++ b/src/lexical.ml
@@ -206,7 +206,7 @@ let tag ?start ?stop (tb : GText.buffer) =
           | INFIXOP3 _
           | INFIXOP4 _
           | PREFIXOP _
-          | HASH
+          | HASH | HASHOP _
             -> "infix"
           | LABEL _
           | OPTLABEL _

--- a/src/lexical.ml
+++ b/src/lexical.ml
@@ -180,6 +180,7 @@ let tag ?start ?stop (tb : GText.buffer) =
           | METHOD
           | MODULE
           | MUTABLE
+          | NONREC
           | PRIVATE
           | REC
           | TYPE

--- a/src/lexical.ml
+++ b/src/lexical.ml
@@ -166,6 +166,7 @@ let tag ?start ?stop (tb : GText.buffer) =
           | WITH
             -> "control"
           | AND
+          | ANDOP _
           | AS
           | BAR
           | CLASS
@@ -177,6 +178,7 @@ let tag ?start ?stop (tb : GText.buffer) =
           | FUNCTOR
           | INHERIT
           | LET
+          | LETOP _
           | METHOD
           | MODULE
           | MUTABLE

--- a/src/lexical.ml
+++ b/src/lexical.ml
@@ -250,6 +250,7 @@ let tag ?start ?stop (tb : GText.buffer) =
           | COMMA | DOT | DOTDOT | COLONCOLON | COLONEQUAL | UNDERSCORE
           | PLUSDOT | MINUSDOT
           | PLUSEQ | PERCENT
+          | DOTOP _
             -> "symbol"
           | LBRACKETAT | LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETATAT | LBRACKETATATAT
             -> in_annotation:= true; "annotation"

--- a/src/lexical_markup.ml
+++ b/src/lexical_markup.ml
@@ -141,6 +141,7 @@ let parse pref =
               -> "structure"
             | CHAR _
             | STRING _
+            | QUOTED_STRING_EXPR _ | QUOTED_STRING_ITEM _
               -> "char"
             (*| BACKQUOTE*)
             | INFIXOP0 _

--- a/src/lexical_markup.ml
+++ b/src/lexical_markup.ml
@@ -192,6 +192,7 @@ let parse pref =
             | COMMA | DOT | DOTDOT | COLONCOLON | COLONEQUAL | UNDERSCORE
             | PLUSDOT | MINUSDOT
             | PLUSEQ | PERCENT
+            | DOTOP _
               -> "symbol"
             | LBRACKETAT | LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETATAT | LBRACKETATATAT
               -> in_annotation:= true; "annotation"

--- a/src/lexical_markup.ml
+++ b/src/lexical_markup.ml
@@ -107,6 +107,7 @@ let parse pref =
             | WITH
               -> "control"
             | AND
+            | ANDOP _
             | AS
             | BAR
             | CLASS
@@ -118,6 +119,7 @@ let parse pref =
             | FUNCTOR
             | INHERIT
             | LET
+            | LETOP _
             | METHOD
             | MODULE
             | MUTABLE

--- a/src/lexical_markup.ml
+++ b/src/lexical_markup.ml
@@ -121,6 +121,7 @@ let parse pref =
             | METHOD
             | MODULE
             | MUTABLE
+            | NONREC
             | PRIVATE
             | REC
             | TYPE

--- a/src/lexical_markup.ml
+++ b/src/lexical_markup.ml
@@ -46,12 +46,6 @@ end
 
 open Range
 
-let tag_lident = function
-  | _, METHOD, _, _ | _, PRIVATE, _, _ -> "method_name_def"
-  | _, IN, _, _ | _, INITIALIZER, _, _ | _, NEW, _, _ | _, OF, _, _ -> "lident"
-  | "define", _, _, _  -> "name_def"
-  | _ -> "lident";;
-
 let parse pref =
   let tags = pref.Preferences.pref_tags in
   let _, _, bgcolor_highlight = Preferences.preferences#get.Preferences.pref_editor_mark_occurrences in
@@ -85,6 +79,7 @@ let parse pref =
     let last_but_one = ref EOF in
     let in_record = ref false in
     let in_record_label = ref false in
+    let in_annotation = ref false in
     try
       while true do
         try
@@ -159,6 +154,7 @@ let parse pref =
             | TILDE
               -> "label"
             | UIDENT _ | BACKQUOTE -> "uident"
+            | LIDENT _ when !in_annotation -> "annotation"
             | LIDENT _ ->
                 begin match !last with
                 | QUESTION | TILDE -> "label"
@@ -189,11 +185,16 @@ let parse pref =
             | LBRACE -> in_record := true; in_record_label := true; "symbol"
             | RBRACE -> in_record := false; in_record_label := false; "symbol"
             | EQUAL when !in_record -> in_record_label := false; "symbol"
-            | LPAREN | RPAREN | LBRACKET | BARRBRACKET| RBRACKET | LBRACKETLESS | GREATERRBRACKET
+            | LPAREN | RPAREN | LBRACKET | BARRBRACKET | LBRACKETLESS | GREATERRBRACKET
             | LBRACELESS | GREATERRBRACE | LBRACKETBAR | LESSMINUS
             | EQUAL | PLUS | MINUS | STAR | QUOTE | SEMI | SEMISEMI | MINUSGREATER
-            | COMMA | DOT | DOTDOT | COLONCOLON | COLONEQUAL (*| LBRACE*) (*| RBRACE*) | UNDERSCORE
+            | COMMA | DOT | DOTDOT | COLONCOLON | COLONEQUAL | UNDERSCORE
+            | PLUSDOT | MINUSDOT
+            | PLUSEQ | PERCENT
               -> "symbol"
+            | LBRACKETAT | LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETATAT | LBRACKETATATAT
+              -> in_annotation:= true; "annotation"
+            | RBRACKET -> if !in_annotation then (in_annotation := false; "annotation") else "symbol"
             | ASSERT -> "custom"
             | EOF -> raise End_of_file
             | _ -> ""

--- a/src/lexical_markup.ml
+++ b/src/lexical_markup.ml
@@ -147,7 +147,7 @@ let parse pref =
             | INFIXOP3 _
             | INFIXOP4 _
             | PREFIXOP _
-            | HASH
+            | HASH | HASHOP _
               -> "infix"
             | LABEL _
             | OPTLABEL _

--- a/src/lexical_markup.ml
+++ b/src/lexical_markup.ml
@@ -151,6 +151,7 @@ let parse pref =
             | INFIXOP4 _
             | PREFIXOP _
             | HASH | HASHOP _
+            | BANG
               -> "infix"
             | LABEL _
             | OPTLABEL _
@@ -189,20 +190,22 @@ let parse pref =
             | LBRACE -> in_record := true; in_record_label := true; "symbol"
             | RBRACE -> in_record := false; in_record_label := false; "symbol"
             | EQUAL when !in_record -> in_record_label := false; "symbol"
-            | LPAREN | RPAREN | LBRACKET | BARRBRACKET | LBRACKETLESS | GREATERRBRACKET
+            | LPAREN | RPAREN | LBRACKET | BARRBRACKET | LBRACKETLESS | LBRACKETGREATER | GREATERRBRACKET
             | LBRACELESS | GREATERRBRACE | LBRACKETBAR | LESSMINUS
             | EQUAL | PLUS | MINUS | STAR | QUOTE | SEMI | SEMISEMI | MINUSGREATER
             | COMMA | DOT | DOTDOT | COLONCOLON | COLONEQUAL | UNDERSCORE
-            | PLUSDOT | MINUSDOT
+            | PLUSDOT | MINUSDOT | LESS | GREATER
             | PLUSEQ | PERCENT
+            | COLONGREATER
             | DOTOP _
               -> "symbol"
             | LBRACKETAT | LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETATAT | LBRACKETATATAT
               -> in_annotation:= true; "annotation"
             | RBRACKET -> if !in_annotation then (in_annotation := false; "annotation") else "symbol"
             | ASSERT -> "custom"
+            | DOCSTRING _ | COMMENT _ -> "comment"
+            | EOL -> ""
             | EOF -> raise End_of_file
-            | _ -> ""
           end;
 
           Buffer.add_string out (Glib.Markup.escape_text (String.sub text !pos (lstart - !pos)));

--- a/src/preferences.ml
+++ b/src/preferences.ml
@@ -149,7 +149,8 @@ let default_tags = [
   "highlight";
   "highlight_current_line";
   "record_label";
-  "selection"
+  "selection";
+  "annotation";
 ]
 
 let tag_labels = List.combine default_tags [
@@ -173,6 +174,7 @@ let tag_labels = List.combine default_tags [
     "Line highlight";
     "Record label";
     "Selection";
+    "Annotation";
   ]
 
 let default_colors : text_properties list = [
@@ -196,6 +198,7 @@ let default_colors : text_properties list = [
   (`NAME "#C3FF96"),      `NORMAL, `NORMAL, `NONE, `MEDIUM, (true,  `NAME "#FFFFFF");(* #E8F2FF *) (* #F7F7D7 *) (*"#F9F9CA"*) (* #EBF9FF *)
   (`NAME "#474747"),      `NORMAL, `ITALIC, `NONE, `MEDIUM, (true,  `NAME "#FFFFFF");
   (`NAME "#FFFFFF"),      `NORMAL, `NORMAL, `NONE, `MEDIUM, (false, `NAME "#128C4C"); (* #1F80ED *)
+  (`NAME "#444488"),      `NORMAL, `ITALIC, `NONE, `MEDIUM, (true,  `NAME "FFFFFF");
 ]
 
 let create_defaults () = {
@@ -399,8 +402,8 @@ let to_xml pref =
         Xml.Element ("pref_editor_bak", [], [Xml.PCData (string_of_bool pref.pref_editor_bak)]);
         begin
           let enabled, under_cursor, color = pref.pref_editor_mark_occurrences in
-          Xml.Element ("pref_editor_mark_occurrences", 
-                       ["enabled", (string_of_bool enabled); 
+          Xml.Element ("pref_editor_mark_occurrences",
+                       ["enabled", (string_of_bool enabled);
                         "under_cursor", (string_of_bool under_cursor)], [Xml.PCData color]);
         end;
         Xml.Element ("pref_editor_custom_templ_filename", [], [Xml.PCData (pref.pref_editor_custom_templ_filename)]);
@@ -546,10 +549,10 @@ let from_file filename =
       | "pref_editor_format_on_save" -> pref.pref_editor_format_on_save <- bool_of_string (value node)
       | "pref_editor_bak" -> pref.pref_editor_bak <- bool_of_string (value node)
       | "pref_editor_custom_templ_filename" -> pref.pref_editor_custom_templ_filename <- value node
-      | "pref_editor_mark_occurrences" -> 
+      | "pref_editor_mark_occurrences" ->
           pref.pref_editor_mark_occurrences <- (
-            (bool_of_string (Xml.attrib node "enabled")), 
-            (try bool_of_string (Xml.attrib node "under_cursor") with Xml.No_attribute _ -> true), 
+            (bool_of_string (Xml.attrib node "enabled")),
+            (try bool_of_string (Xml.attrib node "under_cursor") with Xml.No_attribute _ -> true),
             value node)
       | "pref_editor_left_margin" -> pref.pref_editor_left_margin <- int_of_string (value node)
       | "pref_editor_pixels_lines" -> pref.pref_editor_pixels_lines <- (int_of_string (Xml.attrib node "above")), (int_of_string (Xml.attrib node "below"))

--- a/src/preferences_apply.ml
+++ b/src/preferences_apply.ml
@@ -27,12 +27,12 @@ let apply (view : Text.view) pref =
   view#set_left_margin (pref.Preferences.pref_editor_left_margin + Oe_config.current_line_width);
   view#set_current_line_border_x1 (view#left_margin - (max 1 (Oe_config.current_line_width / 2)) - 1);
   view#set_current_line_border_x2 (view#left_margin - Oe_config.current_line_width / 2 + Oe_config.current_line_border_adjust + 1);
-  kprintf GtkMain.Rc.parse_string "
-style \"s1\" {
+  kprintf GtkMain.Rc.parse_string {|
+style "s1" {
   GtkTextView::cursor_aspect_ratio = %.1f
 }
-class \"GtkTextView\" style \"s1\"
-" pref.Preferences.pref_editor_cursor_aspect_ratio;
+class "GtkTextView" style "s1"
+|} pref.Preferences.pref_editor_cursor_aspect_ratio;
   let above, below = pref.Preferences.pref_editor_pixels_lines in
   view#set_pixels_above_lines above;
   view#set_pixels_below_lines below;


### PR DESCRIPTION
which were added in 4.02. Some other minor fixes.

Which currently looks like this.
![gnome-shell-screenshot-J353A1](https://user-images.githubusercontent.com/246236/136705371-c0ba5780-614f-4072-a313-78b3bff5be2c.png)

Update: Update the handling of tokens to be up to date with all changes in the 4.02-4.13 versions.
A nice bonus is that LETOPs  (`let*` and friends are now properly highlighted)