### PR TITLE
Fix: Preferences color pickers now correctly retain selected colors (…

### DIFF
--- a/src/pref_color.ml
+++ b/src/pref_color.ml
@@ -23,6 +23,8 @@
 open Printf
 open Pref_page
 open Preferences
+open Settings_t
+open Button_Color
 
 (** pref_color *)
 class pref_color title ?packing () =
@@ -159,27 +161,27 @@ class pref_color title ?packing () =
           button_tag_bg#misc#set_sensitive (not check_tag_bg#active)));
 
     method write pref =
-      Preferences.Color.set_themed_color pref.editor_bg_color_popup (color_name button_tag_bg_popup#color);
-      Preferences.Color.set_themed_color pref.editor_fg_color_popup (color_name button_tag_fg_popup#color);
+      Preferences.Color.set_themed_color pref.editor_bg_color_popup (get_color button_tag_bg_popup);
+      Preferences.Color.set_themed_color pref.editor_fg_color_popup (get_color button_tag_fg_popup);
       pref.editor_bg_color_theme <- false;
-      Preferences.Color.set_themed_color pref.editor_bg_color_user (color_name button_default_bg#color);
+      Preferences.Color.set_themed_color pref.editor_bg_color_user (get_color button_default_bg);
       pref.editor_tags <- tags;
       let ltags, prop = tags |> List.map (fun t -> t.Settings_t.name, t) |> List.split in
       Lexical.tags := ltags;
       Lexical.colors := prop;
-      Preferences.Color.set_themed_color pref.output_bg_color (color_name button_bg#color);
-      Preferences.Color.set_themed_color pref.output_stdin_fg_color (color_name button_fg_stdin#color);
-      Preferences.Color.set_themed_color pref.output_stdout_fg_color (color_name button_fg_stdout#color);
-      Preferences.Color.set_themed_color pref.output_err_fg_color (color_name button_fg_err#color);
-      Preferences.Color.set_themed_color pref.output_warn_fg_color (color_name button_fg_warn#color);
-      Preferences.Color.set_themed_color pref.editor_ocamldoc_paragraph_bgcolor_1 (Some (color_name button_odoc_bg#color));
-      Preferences.Color.set_themed_color pref.editor_ocamldoc_paragraph_bgcolor_2 (Some (color_name button_odoc_bg2#color));
+      Preferences.Color.set_themed_color pref.output_bg_color (get_color button_bg);
+      Preferences.Color.set_themed_color pref.output_stdin_fg_color (get_color button_fg_stdin);
+      Preferences.Color.set_themed_color pref.output_stdout_fg_color (get_color button_fg_stdout);
+      Preferences.Color.set_themed_color pref.output_err_fg_color (get_color button_fg_err);
+      Preferences.Color.set_themed_color pref.output_warn_fg_color (get_color button_fg_warn);
+      Preferences.Color.set_themed_color pref.editor_ocamldoc_paragraph_bgcolor_1 (Some (get_color button_odoc_bg));
+      Preferences.Color.set_themed_color pref.editor_ocamldoc_paragraph_bgcolor_2 (Some (get_color button_odoc_bg2));
 
     method read pref =
-      button_tag_bg_popup#set_color (GDraw.color (`NAME ?? (pref.editor_bg_color_popup)));
-      button_tag_fg_popup#set_color (GDraw.color (`NAME ?? (pref.editor_fg_color_popup)));
+      set_color button_tag_bg_popup ??(pref.editor_bg_color_popup);
+      set_color button_tag_fg_popup ??(pref.editor_fg_color_popup);
       tags <- List.sort (fun a b -> compare a.Settings_t.name b.name) pref.editor_tags;
-      button_default_bg#set_color (GDraw.color (`NAME (?? (pref.editor_bg_color_user))));
+      set_color button_default_bg ??(pref.editor_bg_color_user);
       tag_model#clear();
       List.iter begin fun tag ->
         let tagname = tag.Settings_t.name in
@@ -189,13 +191,13 @@ class pref_color title ?packing () =
         tag_model#set ~row ~column:lab_col label;
       end tags;
       view_tag#selection#select_path (GTree.Path.create [0]);
-      button_bg#set_color (GDraw.color (`NAME ?? (pref.output_bg_color)));
-      button_fg_stdin#set_color (GDraw.color (`NAME ?? (pref.output_stdin_fg_color)));
-      button_fg_stdout#set_color (GDraw.color (`NAME ?? (pref.output_stdout_fg_color)));
-      button_fg_err#set_color (GDraw.color (`NAME ?? (pref.output_err_fg_color)));
-      button_fg_warn#set_color (GDraw.color (`NAME ?? (pref.output_warn_fg_color)));
-      ?? (pref.editor_ocamldoc_paragraph_bgcolor_1) |> Gaux.may ~f:(fun color -> button_odoc_bg#set_color (GDraw.color (`NAME color)));
-      ?? (pref.editor_ocamldoc_paragraph_bgcolor_2) |> Gaux.may ~f:(fun color -> button_odoc_bg2#set_color (GDraw.color (`NAME color)));
+      set_color button_bg ??(pref.output_bg_color);
+      set_color button_fg_stdin ??(pref.output_stdin_fg_color);
+      set_color button_fg_stdout ??(pref.output_stdout_fg_color);
+      set_color button_fg_err ??(pref.output_err_fg_color);
+      set_color button_fg_warn ??(pref.output_warn_fg_color);
+      ?? (pref.editor_ocamldoc_paragraph_bgcolor_1) |> Option.iter (fun color -> set_color button_odoc_bg color);
+      ?? (pref.editor_ocamldoc_paragraph_bgcolor_2) |> Option.iter (fun color -> set_color button_odoc_bg2 color);
       self#update_preview ();
 
     method private read_tags () =
@@ -209,12 +211,12 @@ class pref_color title ?packing () =
             let open Settings_t in
             match List.find_opt (fun t -> t.name = tname) tags with
             | Some t ->
-                button_tag_fg#set_color (GDraw.color (`NAME ?? (t.color)));
+                set_color button_tag_fg ??(t.color);
                 scale_tag_weight#adjustment#set_value (float_of_int t.weight);
                 check_tag_style#set_active (t.style <> `NORMAL);
                 check_tag_underline#set_active (t.underline <> `NONE);
                 check_tag_bg#set_active t.bg_default;
-                button_tag_bg#set_color (GDraw.color (`NAME ?? (t.bg_color)));
+                set_color button_tag_bg ??(t.bg_color);
             | _ -> ()
           end;
           if Oe_config.ocamldoc_paragraph_bgcolor_enabled && tname = "ocamldoc"
@@ -239,13 +241,13 @@ class pref_color title ?packing () =
       | [] -> ()
 
     method private update_preview () =
-      let color      = button_tag_fg#color in
+      let color      = get_color button_tag_fg in
       let weight     = scale_tag_weight#adjustment#value |> int_of_float in
       let style      = if check_tag_style#active then `ITALIC else `NORMAL in
       let underline  = if check_tag_underline#active then `SINGLE else `NONE in
       let scale      = Preferences.editor_tag_scale current_tag in
       let bg_default = check_tag_bg#active in
-      let bg_color   = button_tag_bg#color in
+      let bg_color   = get_color button_tag_bg in
       if current_tag <> "" then begin
         let prev_tag =
           tags |> List.find_opt (fun t -> t.Settings_t.name = current_tag) |> Option.get
@@ -253,8 +255,8 @@ class pref_color title ?packing () =
         tags <-
           {
             Settings_t.name = current_tag;
-            color = Preferences.Color.new_themed_color (color_name color) prev_tag.color; weight; style; underline;
-            scale = scale; bg_default; bg_color = Preferences.Color.new_themed_color (color_name bg_color) prev_tag.bg_color
+            color = Preferences.Color.new_themed_color color prev_tag.color; weight; style; underline;
+            scale = scale; bg_default; bg_color = Preferences.Color.new_themed_color bg_color prev_tag.bg_color
           } ::
           (List.filter (fun t -> t.Settings_t.name <> current_tag) tags);
       end;
@@ -262,13 +264,13 @@ class pref_color title ?packing () =
         Preferences.preferences#get with
         editor_bg_color_theme = false;
         editor_bg_color_user =
-          Preferences.Color.new_themed_color (color_name button_default_bg#color) Preferences.preferences#get.editor_bg_color_user;
+          Preferences.Color.new_themed_color (get_color button_default_bg) Preferences.preferences#get.editor_bg_color_user;
         editor_ocamldoc_paragraph_bgcolor_1 =
           Preferences.Color.new_themed_color
-            (Some (color_name button_odoc_bg#color)) Preferences.preferences#get.editor_ocamldoc_paragraph_bgcolor_1;
+            (Some (get_color button_odoc_bg)) Preferences.preferences#get.editor_ocamldoc_paragraph_bgcolor_1;
         editor_ocamldoc_paragraph_bgcolor_2 =
           Preferences.Color.new_themed_color
-            (Some (color_name button_odoc_bg#color)) Preferences.preferences#get.editor_ocamldoc_paragraph_bgcolor_2;
+            (Some (get_color button_odoc_bg2)) Preferences.preferences#get.editor_ocamldoc_paragraph_bgcolor_2;
       } in
       temp_pref.editor_tags <- tags;
       let tag_names, colors = tags |> List.map (fun t -> t.Settings_t.name, t) |> List.split in
@@ -306,25 +308,23 @@ and pref_color_structure title ?packing () =
       self#misc#connect#destroy ~callback:(fun () -> Preferences.preferences#connect#disconnect signal_id) |> ignore;
 
     method read pref =
-      button_color_types#set_color (GDraw.color (`NAME ?? (pref.outline_color_types)));
-      button_color_nor_bg#set_color (GDraw.color (`NAME ?? (pref.outline_color_nor_bg)));
-      button_color_nor_fg#set_color (GDraw.color (`NAME ?? (pref.outline_color_nor_fg)));
-      button_color_sel_bg#set_color (GDraw.color (`NAME ?? (pref.outline_color_sel_bg)));
-      button_color_sel_fg#set_color (GDraw.color (`NAME ?? (pref.outline_color_sel_fg)));
-      button_color_act_bg#set_color (GDraw.color (`NAME ?? (pref.outline_color_act_bg)));
-      button_color_act_fg#set_color (GDraw.color (`NAME ?? (pref.outline_color_act_fg)));
+      set_color button_color_types ??(pref.outline_color_types);
+      set_color button_color_nor_bg ??(pref.outline_color_nor_bg);
+      set_color button_color_nor_fg ??(pref.outline_color_nor_fg);
+      set_color button_color_sel_bg ??(pref.outline_color_sel_bg);
+      set_color button_color_sel_fg ??(pref.outline_color_sel_fg);
+      set_color button_color_act_bg ??(pref.outline_color_act_bg);
+      set_color button_color_act_fg ??(pref.outline_color_act_fg);
       check_alt_rows#set_active (pref.outline_color_alt_rows <> None);
 
     method write pref =
-      Preferences.Color.set_themed_color pref.outline_color_types (color_name button_color_types#color);
-      Preferences.Color.set_themed_color pref.outline_color_nor_bg (color_name button_color_nor_bg#color);
-      Preferences.Color.set_themed_color pref.outline_color_nor_fg (color_name button_color_nor_fg#color);
-      Preferences.Color.set_themed_color pref.outline_color_sel_bg (color_name button_color_sel_bg#color);
-      Preferences.Color.set_themed_color pref.outline_color_sel_fg (color_name button_color_sel_fg#color);
-      Preferences.Color.set_themed_color pref.outline_color_act_bg (color_name button_color_act_bg#color);
-      Preferences.Color.set_themed_color pref.outline_color_act_fg (color_name button_color_act_fg#color);
-      pref.outline_color_alt_rows <- if check_alt_rows#active then
-          Some 0.95
-        else None
+      Preferences.Color.set_themed_color pref.outline_color_types (get_color button_color_types);
+      Preferences.Color.set_themed_color pref.outline_color_nor_bg (get_color button_color_nor_bg);
+      Preferences.Color.set_themed_color pref.outline_color_nor_fg (get_color button_color_nor_fg);
+      Preferences.Color.set_themed_color pref.outline_color_sel_bg (get_color button_color_sel_bg);
+      Preferences.Color.set_themed_color pref.outline_color_sel_fg (get_color button_color_sel_fg);
+      Preferences.Color.set_themed_color pref.outline_color_act_bg (get_color button_color_act_bg);
+      Preferences.Color.set_themed_color pref.outline_color_act_fg (get_color button_color_act_fg);
+      pref.outline_color_alt_rows <- if check_alt_rows#active then Some 0.95 else None
 
   end

--- a/src/pref_editor_display.ml
+++ b/src/pref_editor_display.ml
@@ -24,6 +24,7 @@
 open Pref_page
 open Preferences
 open Settings_t
+open Button_Color
 
 (** pref_editor_display *)
 class pref_editor_display title ?packing () =
@@ -95,18 +96,18 @@ class pref_editor_display title ?packing () =
       pref.editor_highlight_current_line <- check_highlight_current_line#active;
       pref.editor_show_line_numbers <- check_show_line_numbers#active;
       let _, s, d = pref.editor_indent_lines in
-      let solid_color = color_name il_button_solid#color in
-      let dashed_color = color_name il_button_dashed#color in
+      let solid_color = get_color il_button_solid in
+      let dashed_color = get_color il_button_dashed in
       pref.editor_indent_lines <-
         check_indent_lines#active, Preferences.Color.new_themed_color solid_color s,
         Preferences.Color.new_themed_color dashed_color d;
-      let color = color_name rm_button#color in
+      let color = get_color rm_button in
       pref.editor_right_margin_visible <- check_right_margin#active;
       Preferences.Color.set_themed_color pref.editor_right_margin_color color;
       pref.editor_right_margin <- entry_right_margin#value_as_int;
       pref.editor_code_folding_enabled <- check_code_folding#active;
       pref.editor_show_global_gutter <- check_global_gutter#active;
-      let color = color_name mo_button#color in
+      let color = get_color mo_button in
       pref.editor_mark_occurrences_enabled <- check_mark_occurrences#active;
       pref.editor_mark_occurrences_under_cursor <- check_mo_uc#active;
       Preferences.Color.set_themed_color pref.editor_mark_occurrences_bg_color color;
@@ -124,18 +125,18 @@ class pref_editor_display title ?packing () =
       check_right_margin#set_active (not enabled);
       check_right_margin#set_active enabled;
       entry_right_margin#set_value (float pref.editor_right_margin);
-      rm_button#set_color (GDraw.color (`NAME ?? (pref.editor_right_margin_color)));
+      set_color rm_button ??(pref.editor_right_margin_color);
       check_code_folding#set_active (pref.editor_code_folding_enabled);
       check_global_gutter#set_active (pref.editor_show_global_gutter);
       check_mark_occurrences#set_active (not pref.editor_mark_occurrences_enabled);
       check_mark_occurrences#set_active (pref.editor_mark_occurrences_enabled);
       check_mo_uc#set_active pref.editor_mark_occurrences_under_cursor;
-      mo_button#set_color (GDraw.color (`NAME ?? (pref.editor_mark_occurrences_bg_color)));
+      set_color mo_button ??(pref.editor_mark_occurrences_bg_color);
       check_show_dot_leaders#set_active pref.editor_dot_leaders;
       check_current_line_border#set_active pref.editor_current_line_border;
       check_highlight_current_line#set_active (not pref.editor_highlight_current_line);
       check_highlight_current_line#set_active pref.editor_highlight_current_line;
-      il_button_solid#set_color (GDraw.color (`NAME ?? color_s));
-      il_button_dashed#set_color (GDraw.color (`NAME ?? color_d));
+      set_color il_button_solid ??color_s;
+      set_color il_button_dashed ??color_d;
   end
 


### PR DESCRIPTION
…#84)

Introduced a `Button_Color` module to reliably handle color values for `GButton.color_button`, working around an issue where `GButton.color_button#color` would return an incorrect value. Updated `pref_color.ml` and `pref_editor_display.ml` to use the new `Button_Color.get_color` and `Button_Color.set_color` for all color preference settings. Removed the old `color_name` helper function.
Fixes https://github.com/ocamleditor/ocamleditor/issues/84